### PR TITLE
fix: 이전 PR에서 누락된 변경사항 반영

### DIFF
--- a/src/components/Chat/model.test.ts
+++ b/src/components/Chat/model.test.ts
@@ -4,7 +4,7 @@
 import { describe, test, expect } from '@jest/globals';
 import { aiOptions, DEFAULT_LLM } from './model';
 
-describe('aiOptions - AI 모델 선택 옵션 상수', () => {
+describe('aiOptions', () => {
     test('최소 하나 이상의 AI 옵션이 있어야 함', () => {
         expect(aiOptions.length).toBeGreaterThan(0);
     });
@@ -30,27 +30,33 @@ describe('aiOptions - AI 모델 선택 옵션 상수', () => {
         });
     });
 
-    test('현재 모든 옵션에 provider 필드가 있어야 함 (타입은 선택적이지만 런타임 검증)', () => {
+    test('현재 모든 옵션에 provider 필드가 있어야 함', () => {
         aiOptions.forEach((option) => {
-            expect(option.provider).toBeDefined();
+            expect(option).toHaveProperty('provider');
             expect(typeof option.provider).toBe('string');
-            expect(option.provider?.length).toBeGreaterThan(0);
+            expect(option.provider!.length).toBeGreaterThan(0);
         });
     });
 
-    test('각 옵션의 value는 고유해야 함 (LLM 선택 시 식별자로 사용)', () => {
+    test('각 옵션의 value는 고유해야 함', () => {
         const values = aiOptions.map((option) => option.value);
         const uniqueValues = new Set(values);
         expect(uniqueValues.size).toBe(values.length);
     });
 });
 
-describe('DEFAULT_LLM - 기본 AI 모델', () => {
+describe('DEFAULT_LLM', () => {
     test('DEFAULT_LLM이 aiOptions에 포함되어야 함', () => {
         expect(aiOptions).toContain(DEFAULT_LLM);
     });
 
-    test('DEFAULT_LLM은 aiOptions의 첫 번째 요소여야 함 (UI 기본 선택값)', () => {
+    test('DEFAULT_LLM은 aiOptions의 첫 번째 요소여야 함', () => {
         expect(DEFAULT_LLM).toBe(aiOptions[0]);
+    });
+
+    test('DEFAULT_LLM은 필수 필드를 가져야 함', () => {
+        expect(DEFAULT_LLM).toHaveProperty('description');
+        expect(DEFAULT_LLM).toHaveProperty('value');
+        expect(DEFAULT_LLM).toHaveProperty('displayLabel');
     });
 });


### PR DESCRIPTION
## Summary
이전 PR들에서 cherry-pick 과정에서 누락된 변경사항들을 반영합니다.

### 변경 내용
- **embedding-scheduler/route.ts**: `job_name` 타입을 `string | null`에서 `string`으로 수정
- **docs/test/test-status.md**: 테스트 파일 개수 업데이트 (22개 → 23개), Chat 컴포넌트 테스트 섹션 추가
- **src/components/Chat/model.test.ts**: 테스트 코드 스타일 개선 (describe 문자열 간소화, expect 문법 정리)
- **package.json**: 중복 필드 정리, `@types/pg` devDependency 제거

## Test plan
- [ ] 빌드 성공 확인
- [ ] `npm run test` 실행하여 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)